### PR TITLE
Fixes/tweaks for compilation under Arch Linux

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -132,6 +132,7 @@ distclean:
 	rm -f ./scripts/clprocd
 	rm -f ndk.sh
 	rm -f install-message.txt
+	rm -f config.log config.status
 
 echo-install:
 	echo $(INSTALL_BIN_DIR)

--- a/Makefile.in
+++ b/Makefile.in
@@ -131,6 +131,7 @@ distclean:
 	rm -f Makefile
 	rm -f ./scripts/clprocd
 	rm -f ndk.sh
+	rm -f install-message.txt
 
 echo-install:
 	echo $(INSTALL_BIN_DIR)

--- a/configure
+++ b/configure
@@ -3875,9 +3875,9 @@ elif ! test x$tmp_test_libelf = x[libelf.so.0]; then
 fi;
 
 libelf_inc="-I$LIBELF_PATH/include"
-libelf_lib="-L$LIBELF_PATH/lib -lelf"
+libelf_lib="-Wl,-rpath,$LIBELF_PATH/lib -L$LIBELF_PATH/lib -lelf"
 LIBELF_INC="-I$LIBELF_PATH/include"
-LIBELF_LIB="-L$LIBELF_PATH/lib -lelf"
+LIBELF_LIB="-Wl,-rpath,$LIBELF_PATH/lib -L$LIBELF_PATH/lib -lelf"
 
 ### XXX clean up this syntax - above - for setting paths and such -DAR
 

--- a/configure
+++ b/configure
@@ -4315,16 +4315,16 @@ ac_config_files="$ac_config_files src/libocl/Makefile"
 
 	ac_config_files="$ac_config_files src/libcoprthr/arch/x86_64/Makefile"
 
+if test x$enable_epiphany = xyes; then
+#	AC_CONFIG_FILES([src/libcoprthr-e/Makefile])
+#	AC_CONFIG_FILES([test/test_libcoprthr-e/Makefile])
 	ac_config_files="$ac_config_files src/libcoprthr/arch/e32/Makefile"
+fi;
 
 	ac_config_files="$ac_config_files src/libcoprthr_opencl/Makefile"
 
 	ac_config_files="$ac_config_files src/libcoprthrcc/Makefile"
 
-#fi;
-#if test x$enable_epiphany = xyes; then
-#	AC_CONFIG_FILES([src/libcoprthr-e/Makefile])
-#	AC_CONFIG_FILES([test/test_libcoprthr-e/Makefile])
 #fi;
 ac_config_files="$ac_config_files src/libclelf/Makefile"
 
@@ -4376,7 +4376,7 @@ ac_config_files="$ac_config_files examples/bdt_em3d/Makefile"
 
 ac_config_files="$ac_config_files examples/bdt_nbody/Makefile"
 
-ac_config_files="$ac_config_files examples/bdt_nbody_e32/Makefile"
+#ac_config_files="$ac_config_files examples/bdt_nbody_e32/Makefile"
 
 ac_config_files="$ac_config_files examples/bdt_nbody_tutorial/Makefile"
 
@@ -5159,7 +5159,7 @@ do
     "examples/clete_clvector_example/Makefile") CONFIG_FILES="$CONFIG_FILES examples/clete_clvector_example/Makefile" ;;
     "examples/bdt_em3d/Makefile") CONFIG_FILES="$CONFIG_FILES examples/bdt_em3d/Makefile" ;;
     "examples/bdt_nbody/Makefile") CONFIG_FILES="$CONFIG_FILES examples/bdt_nbody/Makefile" ;;
-    "examples/bdt_nbody_e32/Makefile") CONFIG_FILES="$CONFIG_FILES examples/bdt_nbody_e32/Makefile" ;;
+#    "examples/bdt_nbody_e32/Makefile") CONFIG_FILES="$CONFIG_FILES examples/bdt_nbody_e32/Makefile" ;;
     "examples/bdt_nbody_tutorial/Makefile") CONFIG_FILES="$CONFIG_FILES examples/bdt_nbody_tutorial/Makefile" ;;
     "examples/bdt_nbody_tutorial_2/Makefile") CONFIG_FILES="$CONFIG_FILES examples/bdt_nbody_tutorial_2/Makefile" ;;
     "examples/parallella/Makefile") CONFIG_FILES="$CONFIG_FILES examples/parallella/Makefile" ;;

--- a/configure.in
+++ b/configure.in
@@ -529,9 +529,9 @@ elif ! test x$tmp_test_libelf = x@<:@libelf.so.0@:>@; then
 fi;
 
 libelf_inc="-I$LIBELF_PATH/include"
-libelf_lib="-L$LIBELF_PATH/lib -lelf"
+libelf_lib="-Wl,-rpath,$LIBELF_PATH/lib -L$LIBELF_PATH/lib -lelf"
 LIBELF_INC="-I$LIBELF_PATH/include"
-LIBELF_LIB="-L$LIBELF_PATH/lib -lelf"
+LIBELF_LIB="-Wl,-rpath,$LIBELF_PATH/lib -L$LIBELF_PATH/lib -lelf"
 
 ### XXX clean up this syntax - above - for setting paths and such -DAR
 

--- a/configure.in
+++ b/configure.in
@@ -908,13 +908,13 @@ AC_CONFIG_FILES([src/libocl/Makefile])
 #else
 	AC_CONFIG_FILES([src/libcoprthr/Makefile])
 	AC_CONFIG_FILES([src/libcoprthr/arch/x86_64/Makefile])
-	AC_CONFIG_FILES([src/libcoprthr/arch/e32/Makefile])
-	AC_CONFIG_FILES([src/libcoprthr_opencl/Makefile])
-	AC_CONFIG_FILES([src/libcoprthrcc/Makefile])
-#fi;
-#if test x$enable_epiphany = xyes; then
+if test x$enable_epiphany = xyes; then
 #	AC_CONFIG_FILES([src/libcoprthr-e/Makefile])
 #	AC_CONFIG_FILES([test/test_libcoprthr-e/Makefile])
+	AC_CONFIG_FILES([src/libcoprthr/arch/e32/Makefile])
+fi;
+	AC_CONFIG_FILES([src/libcoprthr_opencl/Makefile])
+	AC_CONFIG_FILES([src/libcoprthrcc/Makefile])
 #fi;
 AC_CONFIG_FILES([src/libclelf/Makefile])
 AC_CONFIG_FILES([src/libclrpc/Makefile])
@@ -941,7 +941,7 @@ AC_CONFIG_FILES([examples/clete_clmulti_array_example/Makefile])
 AC_CONFIG_FILES([examples/clete_clvector_example/Makefile])
 AC_CONFIG_FILES([examples/bdt_em3d/Makefile])
 AC_CONFIG_FILES([examples/bdt_nbody/Makefile])
-AC_CONFIG_FILES([examples/bdt_nbody_e32/Makefile])
+#AC_CONFIG_FILES([examples/bdt_nbody_e32/Makefile])
 AC_CONFIG_FILES([examples/bdt_nbody_tutorial/Makefile])
 AC_CONFIG_FILES([examples/bdt_nbody_tutorial_2/Makefile])
 AC_CONFIG_FILES([examples/parallella/Makefile])

--- a/examples/bdt_nbody_e32/Makefile.in
+++ b/examples/bdt_nbody_e32/Makefile.in
@@ -63,4 +63,5 @@ clean:
 
 distclean: clean
 	rm -f *.x
+	rm -f Makefile
 

--- a/include/elf.h
+++ b/include/elf.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2008 The Android Open Source Project
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+#ifndef _ELF_H
+#define _ELF_H
+
+/* these definitions are missing from the BSD sources */
+enum {
+    AT_NULL = 0,
+    AT_IGNORE,
+    AT_EXECFD,
+    AT_PHDR,
+    AT_PHENT,
+    AT_PHNUM,
+    AT_PAGESZ,
+    AT_BASE,
+    AT_FLAGS,
+    AT_ENTRY,
+    AT_NOTELF,
+    AT_UID,
+    AT_EUID,
+    AT_GID,
+    AT_EGID,
+    AT_PLATFORM,
+    AT_HWCAP,
+    AT_CLKTCK,
+
+    AT_SECURE = 23
+};
+
+#include <stdint.h>
+#include <gelf.h>
+
+#endif /* _ELF_H */
+

--- a/install-message.txt.in
+++ b/install-message.txt.in
@@ -14,9 +14,6 @@ if it is not in the standard search path for libraries.  For example:
 
    export LD_LIBRARY_PATH=@prefix@/lib:$LD_LIBRARY_PATH
 
-Note that you should also have already added /usr/local/lib after the
-installation of libelf-0.8.13.
-
 Please ensure that @prefix@/man is added to  MANPATH
 
 In order to test the installation, make a copy of the test/ directory and type:

--- a/src/libclelf/clelf.h
+++ b/src/libclelf/clelf.h
@@ -47,7 +47,7 @@
 #define ELF_Word 		Elf32_Word
 #define ELF_Half 		Elf32_Half
 #define ELF_Addr 		Elf32_Addr
-#define ELF_Xword 	Elf32_Xword
+#define ELF_Xword 	Elf64_Xword
 #define ELF_Ehdr 		Elf32_Ehdr
 #define ELF_Phdr 		Elf32_Phdr
 #define ELF_Shdr 		Elf32_Shdr

--- a/test/test_stdcl/Makefile.in
+++ b/test/test_stdcl/Makefile.in
@@ -23,6 +23,7 @@ CLSRC = test_arg_int.cl test_arg_int4.cl \
 
 TOPDIR ?= ../
 
+INCS += $(LIBELF_INC)
 LIBS += -lm $(LIBELF_LIB) -lclelf
 
 #INCS = -I/usr/local/browndeer/include

--- a/tools/clcc/Makefile.in
+++ b/tools/clcc/Makefile.in
@@ -39,7 +39,7 @@ LIBELF_LIB = @libelf_lib@
 
 LIB_MIC_LIBS = -L@LIB_MIC_PATH@ -limf -lsvml -lirng -lintlc
 
-INCS = -I$(OPENCL_INC_DIR)
+INCS = -I$(OPENCL_INC_DIR) $(LIBELF_INC)
 
 LIBS = $(LIBELF_LIB) 
 LIBS += -L../../src/libclelf -lclelf

--- a/tools/xclnm/Makefile.in
+++ b/tools/xclnm/Makefile.in
@@ -39,7 +39,7 @@ INCS += $(LIBELF_INC)
 #LIBS = -lfl -lelf 
 ifneq (@ENABLE_ANDROID_CROSS_COMPILE@,1)
 ifneq (@host@,k1om-unknown-linux-gnu)
-LIBS += -lfl
+#LIBS += -lfl
 endif
 endif
 LIBS += $(LIBELF_LIB)


### PR DESCRIPTION
Mostly related to properly linking legacy libelf without conflicting with system's libelf

There is also a conflict related to linking flex in xclnm, and the only solution I found is _not_ to link it. I do not have another platform to test this, but I think it's related to newer versions of flex changing "yylex" behavioir. I've left this as a separate commit so it can be left out of the merge if '-lfl' is needed in that case.
