### PR TITLE
Improve "make install" to help with packaging

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -21,9 +21,10 @@ exec_prefix=@exec_prefix@
 ### this useless define is needed to silence useless autoconf warning
 datarootdir=@datarootdir@
 
-
 INSTALL_BIN_DIR=@bindir@
+INSTALL_ETC_DIR=@sysconfdir@
 INSTALL_LIB_DIR=@libdir@
+INSTALL_DOC_DIR=@docdir@
 INSTALL_INCLUDE_DIR=@includedir@
 INSTALL_MAN_DIR=@mandir@
 
@@ -139,34 +140,29 @@ echo-install:
 	echo $(INSTALL_BIN_DIR)
 
 install: subdirs
-	test -d $(prefix) || install -m 755 -d $(prefix)
-	cp -Rf ./doc $(prefix)
-	cp -Rf ./examples $(prefix)
-	cp -Rf ./test $(prefix)
-	install -m 755 ./tools/scripts/cldebug $(INSTALL_BIN_DIR)
-	install -m 755 ./tools/scripts/clprocd $(INSTALL_BIN_DIR)
+	test -d $(DESTDIR)$(prefix) || install -m 755 -d $(DESTDIR)$(prefix)
+	test -d $(DESTDIR)$(INSTALL_DOC_DIR) || install -m 755 -d $(DESTDIR)$(INSTALL_DOC_DIR)
+	cp -Rf ./doc/* $(DESTDIR)$(INSTALL_DOC_DIR)
+	cp -Rf ./examples $(DESTDIR)$(INSTALL_DOC_DIR)
+	cp -Rf ./test $(DESTDIR)$(INSTALL_DOC_DIR)
+	@chmod -R a+rX $(DESTDIR)$(INSTALL_DOC_DIR)
+	install -m 755 ./tools/scripts/cldebug $(DESTDIR)$(INSTALL_BIN_DIR)
+	install -m 755 ./tools/scripts/clprocd $(DESTDIR)$(INSTALL_BIN_DIR)
 #ifeq (freebsd,$(patsubst freebsd%,freebsd,@build_os@))
 #else
 ##	install -m 755 ./scripts/clprocd /etc/init.d/
 #endif
-	@chmod -R a+rX $(prefix)
-	install -m 644 install-message.txt $(prefix)/install-message.txt
+	install -m 644 install-message.txt $(DESTDIR)$(INSTALL_DOC_DIR)/install-message.txt
 	@cat install-message.txt
-ifeq (@ENABLE_USER_INSTALL@,1)
-	install -m 755 -d $(prefix)/etc
-	install -m 644 ./etc/ocl.conf $(prefix)/etc/ocl.conf
-else
-	install -m 644 ./etc/ocl.conf /etc/ocl.conf
-endif
-
+	test -d $(DESTDIR)$(INSTALL_ETC_DIR) || install -m 755 -d $(DESTDIR)$(INSTALL_ETC_DIR)
+	install -m 644 ./etc/ocl.conf $(DESTDIR)$(INSTALL_ETC_DIR)/ocl.conf
 
 uninstall: subdirs
 ifeq (freebsd,$(patsubst freebsd%,freebsd,@build_os@))
 else
 	rm -f /etc/init.d/clprocd
 endif
-	rm -f /etc/ocl.conf
-
+	rm -f $(DESTDIR)$(INSTALL_ETC_DIR)/ocl.conf
 
 test: 
 	$(MAKE) -C ./test $(MAKEFLAGS) $(MAKECMDGOALS)

--- a/README.markdown
+++ b/README.markdown
@@ -255,9 +255,6 @@ When building from source the configure script supports the following options:
 --enable-old-esdk
   : enable old eSDK API for Epiphany (default=no)
 
---enable-user-install
-  : enable installation by user without roo permission (default=no)
-
 --enable-android-cross-compile
   : enable cross-compile for Android (default=no)
 

--- a/configure
+++ b/configure
@@ -3949,15 +3949,6 @@ if test "${with_opencl_icd_path+set}" = set; then :
     else
       OPENCL_ICD_PATH=$withval
     fi;
-
-else
-
-	if test $enable_user_install -eq 1; then
-		OPENCL_ICD_PATH=$prefix/etc/OpenCL/vendors
-	else
-		OPENCL_ICD_PATH=/etc/OpenCL/vendors
-	fi
-
 fi
 
 

--- a/configure
+++ b/configure
@@ -608,7 +608,6 @@ DEFAULT_CLMESG_LEVEL
 MAX_CLMESG_LEVEL
 ENABLE_MIC_CROSS_COMPILE
 ENABLE_ANDROID_CROSS_COMPILE
-ENABLE_USER_INSTALL
 ENABLE_OLD_ESDK
 ENABLE_EMEK_BUILD
 ENABLE_LIBOCL_HOOK
@@ -703,7 +702,6 @@ enable_epiphany
 enable_libocl_hook
 enable_emek_build
 enable_old_esdk
-enable_user_install
 enable_android_cross_compile
 enable_mic_cross_compile
 with_opencl_platform
@@ -1366,8 +1364,6 @@ Optional Features:
   --enable-libocl-hook    enable libocl hook support (default=no)
   --enable-emek-build     enable build for Epiphany EMEK (default=no)
   --enable-old-esdk       enable old eSDK API for Epiphany (default=no)
-  --enable-user-install   enable installation by user without roo permission
-                          (default=no)
   --enable-android-cross-compile
                           enable cross-compile for Android (default=no)
   --enable-mic-cross-compile
@@ -3271,15 +3267,6 @@ else
   enable_old_esdk=no
 fi
 
-
-# Check whether --enable-user-install was given.
-if test "${enable_user_install+set}" = set; then :
-  enableval=$enable_user_install;
-else
-  enable_user_install=no
-fi
-
-
 # Check whether --enable-android-cross-compile was given.
 if test "${enable_android_cross_compile+set}" = set; then :
   enableval=$enable_android_cross_compile;
@@ -3401,14 +3388,6 @@ if test x$enable_old_esdk != xno; then
 		else
 			echo "disabled "Epiphany old eSDK API""
 			ENABLE_OLD_ESDK=0
-		fi;
-
-if test x$enable_user_install != xno; then
-			echo "enabled "user install without root permission""
-			ENABLE_USER_INSTALL=1
-		else
-			echo "disabled "user install without root permission""
-			ENABLE_USER_INSTALL=0
 		fi;
 
 if test x$enable_android_cross_compile != xno; then

--- a/configure.in
+++ b/configure.in
@@ -597,13 +597,7 @@ AC_ARG_WITH(opencl-icd-path,
       OPENCL_ICD_PATH=$withval
     fi;
   ],
-  [ 
-	if test $enable_user_install -eq 1; then
-		OPENCL_ICD_PATH=$prefix/etc/OpenCL/vendors 
-	else
-		OPENCL_ICD_PATH=/etc/OpenCL/vendors 
-	fi
-	])
+  [])
 
 
 ### set path for libevent

--- a/configure.in
+++ b/configure.in
@@ -102,10 +102,6 @@ AC_ARG_ENABLE(old-esdk,
 	AC_HELP_STRING([--enable-old-esdk],[enable old eSDK API for Epiphany (default=no)]),,
 	enable_old_esdk=no)
 
-AC_ARG_ENABLE(user-install,
-	AC_HELP_STRING([--enable-user-install],[enable installation by user without roo permission (default=no)]),,
-	enable_user_install=no)
-
 AC_ARG_ENABLE(android-cross-compile,
 	AC_HELP_STRING([--enable-android-cross-compile],[enable cross-compile for Android (default=no)]),,
 	enable_android_cross_compile=no)
@@ -137,7 +133,6 @@ SET_OPT($enable_epiphany, ENABLE_EPIPHANY, "epiphany support")
 SET_OPT($enable_libocl_hook, ENABLE_LIBOCL_HOOK, "libocl hook support")
 SET_OPT($enable_emek_build, ENABLE_EMEK_BUILD, "Epiphany EMEK build")
 SET_OPT($enable_old_esdk, ENABLE_OLD_ESDK, "Epiphany old eSDK API")
-SET_OPT($enable_user_install, ENABLE_USER_INSTALL, "user install without root permission")
 SET_OPT($enable_android_cross_compile, ENABLE_ANDROID_CROSS_COMPILE, "Android cross-compile")
 SET_OPT($enable_mic_cross_compile, ENABLE_MIC_CROSS_COMPILE, "MIC cross-compile")
 
@@ -860,7 +855,6 @@ AC_SUBST(ENABLE_EPIPHANY)
 AC_SUBST(ENABLE_LIBOCL_HOOK)
 AC_SUBST(ENABLE_EMEK_BUILD)
 AC_SUBST(ENABLE_OLD_ESDK)
-AC_SUBST(ENABLE_USER_INSTALL)
 AC_SUBST(ENABLE_ANDROID_CROSS_COMPILE)
 AC_SUBST(ENABLE_MIC_CROSS_COMPILE)
 

--- a/doc/app_note_mic_build.html
+++ b/doc/app_note_mic_build.html
@@ -52,14 +52,14 @@
 <h3 id="for-root-installation-as-a-priveleged-admin"><a href="#for-root-installation-as-a-priveleged-admin"><span class="header-section-number">2.1.1</span> For root installation as a priveleged admin</a></h3>
 <p>If you have root access, the build itself should work with all of the defaults. The target install directory will be <code>/usr/local/browndeer</code>. If the Intel compiler is the default C/C++ compiler used, at the present time it may be necessary to disable Fortran bindings in libstdcl using <code>--with-fortran=</code> with no value provided following the equal (=) sign.</p>
 <p>The complete commandline would simply be,</p>
-<pre><code>./configure --with-fortran= --enable-mic-cross-compile</code></pre>
+<pre><code>./configure --with-fortran= --enable-mic-cross-compile --sysconfdir=/etc --localstatedir=/var</code></pre>
 <p>If the pre-requisites libelf (libelf-0.8.13), libconfig, or libevent have been installed in non-standard locations, the options <code>--with-libelf</code>, <code>--with-libconfig</code>, and <code>--with-libevent</code> may be used to make adjustments.<br />See <code>./configure --help</code> for a full listing of customizations.</p>
 <h3 id="for-user-installation-as-an-unpriveleged-user"><a href="#for-user-installation-as-an-unpriveleged-user"><span class="header-section-number">2.1.2</span> For user installation as an unpriveleged user</a></h3>
 <p>If you do not have root access on the platform it is still possible to do a private &quot;user install&quot;. The following paths are assumed to be defined: <code>LIBELF_DIR</code>, <code>LIBCONFIG_DIR</code>, <code>LIBEVENT_DIR</code>, corresponding to the install locations of libelf (libelf-0.8.13), libconfig, and libevent. Additionally we will assume the target installation directory is <code>COPRTHR_INSTALL_DIR</code>.</p>
 <pre><code>./configure --prefix=$COPRTHR_INSTALL_DIR --with-libelf=$LIBELF_DIR \
     --with-libconfig=$LIBCONFIG_DIR --with-libevent=$LIBEVENT_DIR \
     --with-opencl-icd-path=$COPRTHR_INSTALL_DIR/etc/OpenCL/vendors \
-    --enable-user-install --with-fortran= --enable-mic-cross-compile</code></pre>
+    --with-fortran= --enable-mic-cross-compile</code></pre>
 <p>See <code>./configure --help</code> for a full listing of customizations.</p>
 <p> </p>
 <h2 id="build-and-install-the-package"><a href="#build-and-install-the-package"><span class="header-section-number">2.2</span> Build and install the package</a></h2>
@@ -98,15 +98,15 @@ $HOME/.ocl.conf
 <p>The COPRTHR SDK may be built for MIC native execution. However, some limitations arise due to the fact that the MIC accelerator cards will be running a stripped-down Linux kernel. An example is just-in-time (JIT) compilation support from an application running native since the Intel compiler will not be available on the card, only on the host as part of the standard Intel compiler installation. Nevertheless most of the run-time libraries are supported including the core libraries libstdcl, libcoprthr, libcoprthr_opencl, and libclrpc. The lack of JIT compilation support is easily overcome since COPRTHR provides robust support for pre-cross-compiled kernels.</p>
 <p> </p>
 <h2 id="configuration"><a href="#configuration"><span class="header-section-number">3.1</span> Configuration</a></h2>
-<p>Building the COPRTHR SDK for MIC native execution requires cross-compilation on the host using --enable-user-install configuration option. In order to support the cross-compilation the path to the location of the required MIC libraries must be specified. This should be the location where the libimf.so library built for MIC is installed on the host as part of the Intel SDK. This directory will be designated MIC_LIBS_DIR.</p>
+<p>Building the COPRTHR SDK for MIC native execution requires cross-compilation on the host. In order to support the cross-compilation the path to the location of the required MIC libraries must be specified. This should be the location where the libimf.so library built for MIC is installed on the host as part of the Intel SDK. This directory will be designated MIC_LIBS_DIR.</p>
 <p>Prior to building COPRTHR it will be necessary to build the packages libelf (libelf-0.8.13), libconfig, and libevent for the MIC architecture, and specify the location(s) for these packages using MIC_LIBELF_DIR, MIC_LIBCONFIG_DIR, MIC_LIBEVENT_DIR, respectively.</p>
-<p>The location where the COPRTHR SDK build should be (temporarily) installed is designated IC_COPRTHR_INSTAL_DIR. This is a temporary location since all of the packages will need to be copied over to the MIC accelerator card.</p>
+<p>The location where the COPRTHR SDK build should be (temporarily) installed is designated MIC_COPRTHR_INSTAL_DIR. This is a temporary location since all of the packages will need to be copied over to the MIC accelerator card.</p>
 <p>The configuration is then performed with the commandline,</p>
 <pre><code>CC=icc CFLAGS=-mmic ./configure --prefix=$MIC_COPRTHR_INSTALL_DIR \
     --with-libelf=$MIC_LIBELF_DIR --with-libconfig=$MIC_LIBCONFIG_DIR \
     --with-libevent=$MIC_LIBEVENT_DIR \
     --with-opencl-icd-path=$MIC_COPRTHR_INSTALL_DIR/etc/OpenCL/vendors \
-    --enable-user-install --with-fortran= --host=k1om-unknown-linux-gnu \
+    --with-fortran= --host=k1om-unknown-linux-gnu \
     --with-lib-mic=$MIC_LIBS_DIR</code></pre>
 <hr />
 <p> </p>

--- a/doc/app_note_mic_build.txt
+++ b/doc/app_note_mic_build.txt
@@ -47,7 +47,7 @@ time it may be necessary to disable Fortran bindings in libstdcl using
 
 The complete commandline would simply be,
 
-    ./configure --with-fortran= --enable-mic-cross-compile
+    ./configure --with-fortran= --enable-mic-cross-compile --sysconfdir=/etc --localstatedir=/var
 
 If the pre-requisites libelf (libelf-0.8.13), libconfig, or libevent
 have been installed in non-standard locations, the options
@@ -67,7 +67,7 @@ is `COPRTHR_INSTALL_DIR`.
     ./configure --prefix=$COPRTHR_INSTALL_DIR --with-libelf=$LIBELF_DIR \
         --with-libconfig=$LIBCONFIG_DIR --with-libevent=$LIBEVENT_DIR \
         --with-opencl-icd-path=$COPRTHR_INSTALL_DIR/etc/OpenCL/vendors \
-        --enable-user-install --with-fortran= --enable-mic-cross-compile
+        --with-fortran= --enable-mic-cross-compile
 
 See `./configure --help` for a full listing of customizations.
 
@@ -172,12 +172,11 @@ Configuration
 -------------
 
 Building the COPRTHR SDK for MIC native execution requires
-cross-compilation on the host using --enable-user-install configuration
-option. In order to support the cross-compilation the path to the
-location of the required MIC libraries must be specified. This should be
-the location where the libimf.so library built for MIC is installed on
-the host as part of the Intel SDK. This directory will be designated
-MIC\_LIBS\_DIR.
+cross-compilation on the host. In order to support the cross-compilation
+the path to the location of the required MIC libraries must be
+specified. This should be the location where the libimf.so library built
+for MIC is installed on the host as part of the Intel SDK. This
+directory will be designated MIC\_LIBS\_DIR.
 
 Prior to building COPRTHR it will be necessary to build the packages
 libelf (libelf-0.8.13), libconfig, and libevent for the MIC
@@ -185,7 +184,7 @@ architecture, and specify the location(s) for these packages using
 MIC\_LIBELF\_DIR, MIC\_LIBCONFIG\_DIR, MIC\_LIBEVENT\_DIR, respectively.
 
 The location where the COPRTHR SDK build should be (temporarily)
-installed is designated IC\_COPRTHR\_INSTAL\_DIR. This is a temporary
+installed is designated MIC\_COPRTHR\_INSTAL\_DIR. This is a temporary
 location since all of the packages will need to be copied over to the
 MIC accelerator card.
 
@@ -195,7 +194,7 @@ The configuration is then performed with the commandline,
         --with-libelf=$MIC_LIBELF_DIR --with-libconfig=$MIC_LIBCONFIG_DIR \
         --with-libevent=$MIC_LIBEVENT_DIR \
         --with-opencl-icd-path=$MIC_COPRTHR_INSTALL_DIR/etc/OpenCL/vendors \
-        --enable-user-install --with-fortran= --host=k1om-unknown-linux-gnu \
+        --with-fortran= --host=k1om-unknown-linux-gnu \
         --with-lib-mic=$MIC_LIBS_DIR
 
 * * * * *

--- a/doc/application_notes/mic_build/app_note_mic_build.md
+++ b/doc/application_notes/mic_build/app_note_mic_build.md
@@ -48,7 +48,7 @@ value provided following the equal (=) sign.
 The complete commandline would simply be,
 
 ~~~~~~~
-./configure --with-fortran= --enable-mic-cross-compile
+./configure --with-fortran= --enable-mic-cross-compile --sysconfdir=/etc --localstatedir=/var
 ~~~~~~~
 
 If the pre-requisites libelf (libelf-0.8.13), libconfig, or libevent have been
@@ -68,7 +68,7 @@ will assume the target installation directory is `COPRTHR_INSTALL_DIR`.
 ./configure --prefix=$COPRTHR_INSTALL_DIR --with-libelf=$LIBELF_DIR \
 	--with-libconfig=$LIBCONFIG_DIR --with-libevent=$LIBEVENT_DIR \
 	--with-opencl-icd-path=$COPRTHR_INSTALL_DIR/etc/OpenCL/vendors \
-	--enable-user-install --with-fortran= --enable-mic-cross-compile
+	--with-fortran= --enable-mic-cross-compile
 ~~~~~~~
 
 See `./configure --help` for a full listing of customizations.
@@ -172,11 +172,10 @@ COPRTHR provides robust support for pre-cross-compiled kernels.
 ## Configuration
 
 Building the COPRTHR SDK for MIC native execution requires cross-compilation on
-the host using --enable-user-install configuration option.  In order to support
-the cross-compilation the path to the location of the required MIC libraries
-must be specified.  This should be the location where the libimf.so library
-built for MIC is installed on the host as part of the Intel SDK.  This
-directory will be designated MIC_LIBS_DIR.
+the host. In order to support the cross-compilation the path to the location of
+the required MIC libraries must be specified.  This should be the location
+where the libimf.so library built for MIC is installed on the host as part of
+the Intel SDK.  This directory will be designated MIC_LIBS_DIR.
 
 Prior to building COPRTHR it will be necessary to build the packages libelf
 (libelf-0.8.13), libconfig, and libevent for the MIC architecture, and specify
@@ -184,7 +183,7 @@ the location(s) for these packages using MIC_LIBELF_DIR, MIC_LIBCONFIG_DIR,
 MIC_LIBEVENT_DIR, respectively.
 
 The location where the COPRTHR SDK build should be (temporarily) installed
-is designated IC_COPRTHR_INSTAL_DIR.  This is a temporary location since
+is designated MIC_COPRTHR_INSTAL_DIR.  This is a temporary location since
 all of the packages will need to be copied over to the MIC accelerator card.
 
 The configuration is then performed with the commandline,
@@ -194,7 +193,7 @@ CC=icc CFLAGS=-mmic ./configure --prefix=$MIC_COPRTHR_INSTALL_DIR \
 	--with-libelf=$MIC_LIBELF_DIR --with-libconfig=$MIC_LIBCONFIG_DIR \
 	--with-libevent=$MIC_LIBEVENT_DIR \
 	--with-opencl-icd-path=$MIC_COPRTHR_INSTALL_DIR/etc/OpenCL/vendors \
-	--enable-user-install --with-fortran= --host=k1om-unknown-linux-gnu \
+	--with-fortran= --host=k1om-unknown-linux-gnu \
 	--with-lib-mic=$MIC_LIBS_DIR
 ~~~~~~~
 

--- a/doc/coprthr_release_notes-1.6.0.html
+++ b/doc/coprthr_release_notes-1.6.0.html
@@ -172,9 +172,6 @@
 <dt>--enable-old-esdk</dt>
 <dd><p>enable old eSDK API for Epiphany (default=no)</p>
 </dd>
-<dt>--enable-user-install</dt>
-<dd><p>enable installation by user without roo permission (default=no)</p>
-</dd>
 <dt>--enable-android-cross-compile</dt>
 <dd><p>enable cross-compile for Android (default=no)</p>
 </dd>

--- a/doc/coprthr_release_notes-1.6.0.txt
+++ b/doc/coprthr_release_notes-1.6.0.txt
@@ -262,9 +262,6 @@ installation
 --enable-old-esdk
 :   enable old eSDK API for Epiphany (default=no)
 
---enable-user-install
-:   enable installation by user without roo permission (default=no)
-
 --enable-android-cross-compile
 :   enable cross-compile for Android (default=no)
 

--- a/doc/release_notes/v1.6.0/coprthr_release_notes-1.6.0.md
+++ b/doc/release_notes/v1.6.0/coprthr_release_notes-1.6.0.md
@@ -255,9 +255,6 @@ When building from source the configure script supports the following options:
 --enable-old-esdk
   : enable old eSDK API for Epiphany (default=no)
 
---enable-user-install
-  : enable installation by user without roo permission (default=no)
-
 --enable-android-cross-compile
   : enable cross-compile for Android (default=no)
 

--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -24,14 +24,14 @@ all:
 check_root: 
 
 install: check_root $(INSTALL_INCS) 
-	test -d $(INSTALL_INCLUDE_DIR) || install -m 755 -d $(INSTALL_INCLUDE_DIR)
-	test -d $(INSTALL_INCLUDE_DIR)/CL \
-		|| install -m 755 -d $(INSTALL_INCLUDE_DIR)/CL
-	install -m 644 $(INSTALL_INCS_CL) $(INSTALL_INCLUDE_DIR)/CL
+	test -d $(DESTDIR)$(INSTALL_INCLUDE_DIR) || install -m 755 -d $(DESTDIR)$(INSTALL_INCLUDE_DIR)
+	test -d $(DESTDIR)$(INSTALL_INCLUDE_DIR)/CL \
+		|| install -m 755 -d $(DESTDIR)$(INSTALL_INCLUDE_DIR)/CL
+	install -m 644 $(INSTALL_INCS_CL) $(DESTDIR)$(INSTALL_INCLUDE_DIR)/CL
 
 uninstall: check_root
-	rm -f $(addprefix $(INSTALL_INC_DIR)/,$(INSTALL_INCS)) 
-	rm -f $(addprefix $(INSTALL_INC_DIR)/,$(INSTALL_INCS_CL)) 
+	rm -f $(addprefix $(DESTDIR)$(INSTALL_INC_DIR)/,$(INSTALL_INCS))
+	rm -f $(addprefix $(DESTDIR)$(INSTALL_INC_DIR)/,$(INSTALL_INCS_CL))
 
 
 clean:

--- a/src/CLETE/Makefile.in
+++ b/src/CLETE/Makefile.in
@@ -40,11 +40,11 @@ check_root:
 
 #install: check_root all
 install: check_root $(INSTALL_INCS) 
-	test -d $(INSTALL_INCLUDE_DIR) || install -m 755 -d $(INSTALL_INCLUDE_DIR)
-	install -m 644 $(INSTALL_INCS) $(INSTALL_INCLUDE_DIR)
+	test -d $(DESTDIR)$(INSTALL_INCLUDE_DIR) || install -m 755 -d $(DESTDIR)$(INSTALL_INCLUDE_DIR)
+	install -m 644 $(INSTALL_INCS) $(DESTDIR)$(INSTALL_INCLUDE_DIR)
 
 uninstall: check_root
-	rm -f $(addprefix $(INSTALL_INC_DIR)/,$(INSTALL_INCS))
+	rm -f $(addprefix $(DESTDIR)$(INSTALL_INC_DIR)/,$(INSTALL_INCS))
 
 clean:
 	rm -f $(GEN_HDRS)

--- a/src/libclelf/Makefile.in
+++ b/src/libclelf/Makefile.in
@@ -114,14 +114,14 @@ libclelf.a:	$(OBJS)
 
 #install: check_root all
 install: $(INSTALL_INCS) $(INSTALL_LIBS) 
-	test -d $(INSTALL_INCLUDE_DIR) || install -m 755 -d $(INSTALL_INCLUDE_DIR)
-	test -d $(INSTALL_LIB_DIR) || install -m 755 -d $(INSTALL_LIB_DIR)
-	install -m 644 $(INSTALL_INCS) $(INSTALL_INCLUDE_DIR)
-	install -m 644 $(INSTALL_LIBS) $(INSTALL_LIB_DIR)
+	test -d $(DESTDIR)$(INSTALL_INCLUDE_DIR) || install -m 755 -d $(DESTDIR)$(INSTALL_INCLUDE_DIR)
+	test -d $(DESTDIR)$(INSTALL_LIB_DIR) || install -m 755 -d $(DESTDIR)$(INSTALL_LIB_DIR)
+	install -m 644 $(INSTALL_INCS) $(DESTDIR)$(INSTALL_INCLUDE_DIR)
+	install -m 644 $(INSTALL_LIBS) $(DESTDIR)$(INSTALL_LIB_DIR)
 
 uninstall: 
-	rm -f $(addprefix $(INSTALL_INC_DIR)/,$(INSTALL_INCS)) 
-	rm -f $(addprefix $(INSTALL_LIB_DIR)/,$(INSTALL_LIBS)) 
+	rm -f $(addprefix $(DESTDIR)$(INSTALL_INC_DIR)/,$(INSTALL_INCS))
+	rm -f $(addprefix $(DESTDIR)$(INSTALL_LIB_DIR)/,$(INSTALL_LIBS))
 
 
 clean:

--- a/src/libclrpc/Makefile.in
+++ b/src/libclrpc/Makefile.in
@@ -162,17 +162,17 @@ clrpcd: clrpcd.o $(OBJS)
 
 
 install: $(INSTALL_INCS) $(INSTALL_LIBS) $(INSTALL_BINS)
-	test -d $(INSTALL_INCLUDE_DIR) || install -m 755 -d $(INSTALL_INCLUDE_DIR)
-	test -d $(INSTALL_LIB_DIR) || install -m 755 -d $(INSTALL_LIB_DIR)
-	test -d $(INSTALL_BIN_DIR) || install -m 755 -d $(INSTALL_BIN_DIR)
-	install -m 644 $(INSTALL_INCS) $(INSTALL_INCLUDE_DIR)
-	install -m 644 $(INSTALL_LIBS) $(INSTALL_LIB_DIR)
-	install -m 755 $(INSTALL_BINS) $(INSTALL_BIN_DIR)
+	test -d $(DESTDIR)$(INSTALL_INCLUDE_DIR) || install -m 755 -d $(DESTDIR)$(INSTALL_INCLUDE_DIR)
+	test -d $(DESTDIR)$(INSTALL_LIB_DIR) || install -m 755 -d $(DESTDIR)$(INSTALL_LIB_DIR)
+	test -d $(DESTDIR)$(INSTALL_BIN_DIR) || install -m 755 -d $(DESTDIR)$(INSTALL_BIN_DIR)
+	install -m 644 $(INSTALL_INCS) $(DESTDIR)$(INSTALL_INCLUDE_DIR)
+	install -m 644 $(INSTALL_LIBS) $(DESTDIR)$(INSTALL_LIB_DIR)
+	install -m 755 $(INSTALL_BINS) $(DESTDIR)$(INSTALL_BIN_DIR)
 
 uninstall: 
-	rm -f $(addprefix $(INSTALL_INC_DIR)/,$(INSTALL_INCS)) 
-	rm -f $(addprefix $(INSTALL_LIB_DIR)/,$(INSTALL_LIBS)) 
-	rm -f $(addprefix $(INSTALL_BIN_DIR)/,$(INSTALL_BINS)) 
+	rm -f $(addprefix $(DESTDIR)$(INSTALL_INC_DIR)/,$(INSTALL_INCS))
+	rm -f $(addprefix $(DESTDIR)$(INSTALL_LIB_DIR)/,$(INSTALL_LIBS))
+	rm -f $(addprefix $(DESTDIR)$(INSTALL_BIN_DIR)/,$(INSTALL_BINS))
 
 
 clean:

--- a/src/libcoprthr/Makefile.in
+++ b/src/libcoprthr/Makefile.in
@@ -22,14 +22,6 @@ INSTALL_BIN_DIR=@bindir@
 INSTALL_LIB_DIR=@libdir@
 INSTALL_INCLUDE_DIR=@includedir@
 INSTALL_MAN_DIR=@mandir@
-INSTALL_ICD_DIR=@prefix@/icd/
-
-### set custom path for ICD files
-ifneq (@OPENCL_ICD_PATH@,)
-OPENCL_ICD_PATH=@OPENCL_ICD_PATH@
-else
-OPENCL_ICD_PATH=/etc/OpenCL/vendors/
-endif
 
 ifeq (@ENABLE_SILENT@,1)
 DEFS += -DENABLE_SILENT
@@ -182,25 +174,24 @@ libcoprthr.a: $(IMP_OBJS)
 
 
 install: $(SUBDIRS)
-	test -d $(INSTALL_INCLUDE_DIR) || install -m 755 -d $(INSTALL_INCLUDE_DIR)
-	test -d $(INSTALL_INCLUDE_DIR)/coprthr \
-		|| install -m 755 -d $(INSTALL_INCLUDE_DIR)/coprthr
-	test -d $(INSTALL_LIB_DIR) || install -m 755 -d $(INSTALL_LIB_DIR)
-	test -d $(INSTALL_BIN_DIR) || install -m 755 -d $(INSTALL_BIN_DIR)
-	test -d $(INSTALL_ICD_DIR) || install -m 755 -d $(INSTALL_ICD_DIR)
+	test -d $(DESTDIR)$(INSTALL_INCLUDE_DIR) || install -m 755 -d $(DESTDIR)$(INSTALL_INCLUDE_DIR)
+	test -d $(DESTDIR)$(INSTALL_INCLUDE_DIR)/coprthr \
+		|| install -m 755 -d $(DESTDIR)$(INSTALL_INCLUDE_DIR)/coprthr
+	test -d $(DESTDIR)$(INSTALL_LIB_DIR) || install -m 755 -d $(DESTDIR)$(INSTALL_LIB_DIR)
+	test -d $(DESTDIR)$(INSTALL_BIN_DIR) || install -m 755 -d $(DESTDIR)$(INSTALL_BIN_DIR)
 #	install -m 755 libcoprthr.so $(INSTALL_LIB_DIR)
-	install -m 755 $(INSTALL_LIBS) $(INSTALL_LIB_DIR)
-	install -m 755 coprthr.h $(INSTALL_INCLUDE_DIR)
+	install -m 755 $(INSTALL_LIBS) $(DESTDIR)$(INSTALL_LIB_DIR)
+	install -m 755 coprthr.h $(DESTDIR)$(INSTALL_INCLUDE_DIR)
 #	install -m 755 sl_engine.h $(INSTALL_INCLUDE_DIR)
 #	install -m 755 ser_engine.h $(INSTALL_INCLUDE_DIR)
-	install -m 755 workp.h $(INSTALL_INCLUDE_DIR)
-	install -m 755 $(INSTALL_HDRS) $(INSTALL_INCLUDE_DIR)
-	install -m 755 $(INSTALL_COPRTHR_HDRS) $(INSTALL_INCLUDE_DIR)/coprthr
+	install -m 755 workp.h $(DESTDIR)$(INSTALL_INCLUDE_DIR)
+	install -m 755 $(INSTALL_HDRS) $(DESTDIR)$(INSTALL_INCLUDE_DIR)
+	install -m 755 $(INSTALL_COPRTHR_HDRS) $(DESTDIR)$(INSTALL_INCLUDE_DIR)/coprthr
 
 uninstall: $(SUBDIRS)
 #	rm -f $(INSTALL_LIB_DIR)/libcoprthr.so 
-	rm -f $(addprefix $(INSTALL_LIB_DIR)/,$(INSTALL_LIBS))
-	rm -f $(addprefix $(INSTALL_INCLUDE_DIR)/,$(INSTALL_HDRS))
+	rm -f $(addprefix $(DESTDIR)$(INSTALL_LIB_DIR)/,$(INSTALL_LIBS))
+	rm -f $(addprefix $(DESTDIR)$(INSTALL_INCLUDE_DIR)/,$(INSTALL_HDRS))
 
 clean: $(SUBDIRS)
 	rm -f *.o *.so

--- a/src/libcoprthr/arch/e32/Makefile.in
+++ b/src/libcoprthr/arch/e32/Makefile.in
@@ -25,13 +25,12 @@ INSTALL_BIN_DIR=@bindir@
 INSTALL_LIB_DIR=@libdir@
 INSTALL_INCLUDE_DIR=@includedir@
 INSTALL_MAN_DIR=@mandir@
-INSTALL_ICD_DIR=@prefix@/icd/
 
 ### set custom path for ICD files
 #ifneq (@OPENCL_ICD_PATH@,)
 #OPENCL_ICD_PATH=@OPENCL_ICD_PATH@
 #else
-#OPENCL_ICD_PATH=/etc/OpenCL/vendors/
+#OPENCL_ICD_PATH=@sysconfdir@/OpenCL/vendors/
 #endif
 
 ifeq (@ENABLE_SILENT@,1)
@@ -220,20 +219,19 @@ libe_platform.so: $(DEFAULT_E_PLATFORM_LIB)
 
 
 install: 
-	test -d $(INSTALL_INCLUDE_DIR) || install -m 755 -d $(INSTALL_INCLUDE_DIR)
-	test -d $(INSTALL_LIB_DIR) || install -m 755 -d $(INSTALL_LIB_DIR)
-	test -d $(INSTALL_BIN_DIR) || install -m 755 -d $(INSTALL_BIN_DIR)
-	test -d $(INSTALL_ICD_DIR) || install -m 755 -d $(INSTALL_ICD_DIR)
-#	install -m 755 libcoprthr_arch_x86_64.so $(INSTALL_LIB_DIR)
-	install -m 755 $(INSTALL_LIBS) $(INSTALL_LIB_DIR)
-	install -m 755 $(INSTALL_OBJS) $(INSTALL_LIB_DIR)
-	install -m 755 $(INSTALL_HDRS) $(INSTALL_INCLUDE_DIR)
+	test -d $(DESTDIR)$(INSTALL_INCLUDE_DIR) || install -m 755 -d $(DESTDIR)$(INSTALL_INCLUDE_DIR)
+	test -d $(DESTDIR)$(INSTALL_LIB_DIR) || install -m 755 -d $(DESTDIR)$(INSTALL_LIB_DIR)
+	test -d $(DESTDIR)$(INSTALL_BIN_DIR) || install -m 755 -d $(DESTDIR)$(INSTALL_BIN_DIR)
+#	install -m 755 libcoprthr_arch_x86_64.so $(DESTDIR)$(INSTALL_LIB_DIR)
+	install -m 755 $(INSTALL_LIBS) $(DESTDIR)$(INSTALL_LIB_DIR)
+	install -m 755 $(INSTALL_OBJS) $(DESTDIR)$(INSTALL_LIB_DIR)
+	install -m 755 $(INSTALL_HDRS) $(DESTDIR)$(INSTALL_INCLUDE_DIR)
 	ln -sf $(INSTALL_LIB_DIR)/$(DEFAULT_E_PLATFORM_LIB) \
-		$(INSTALL_LIB_DIR)/libe_platform.so
+		$(DESTDIR)$(INSTALL_LIB_DIR)/libe_platform.so
 
 uninstall: 
-	rm -f $(INSTALL_LIB_DIR)/libcoprthr_arch_e32.so 
-	rm -f $(addprefix $(INSTALL_INCLUDE_DIR)/,$(INSTALL_HDRS))
+	rm -f $(DESTDIR)$(INSTALL_LIB_DIR)/libcoprthr_arch_e32.so
+	rm -f $(addprefix $(DESTDIR)$(INSTALL_INCLUDE_DIR)/,$(INSTALL_HDRS))
 
 clean: 
 	rm -f *.o *.so

--- a/src/libcoprthr/arch/e32_legacy/Makefile.in
+++ b/src/libcoprthr/arch/e32_legacy/Makefile.in
@@ -24,13 +24,12 @@ INSTALL_BIN_DIR=@bindir@
 INSTALL_LIB_DIR=@libdir@
 INSTALL_INCLUDE_DIR=@includedir@
 INSTALL_MAN_DIR=@mandir@
-INSTALL_ICD_DIR=@prefix@/icd/
 
 ### set custom path for ICD files
 #ifneq (@OPENCL_ICD_PATH@,)
 #OPENCL_ICD_PATH=@OPENCL_ICD_PATH@
 #else
-#OPENCL_ICD_PATH=/etc/OpenCL/vendors/
+#OPENCL_ICD_PATH=@sysconfdir@/OpenCL/vendors/
 #endif
 
 ifeq (@ENABLE_SILENT@,1)
@@ -219,16 +218,15 @@ libe_platform.so: $(DEFAULT_E_PLATFORM_LIB)
 
 
 install: 
-	test -d $(INSTALL_INCLUDE_DIR) || install -m 755 -d $(INSTALL_INCLUDE_DIR)
-	test -d $(INSTALL_LIB_DIR) || install -m 755 -d $(INSTALL_LIB_DIR)
-	test -d $(INSTALL_BIN_DIR) || install -m 755 -d $(INSTALL_BIN_DIR)
-	test -d $(INSTALL_ICD_DIR) || install -m 755 -d $(INSTALL_ICD_DIR)
-#	install -m 755 libcoprthr_arch_x86_64.so $(INSTALL_LIB_DIR)
-	install -m 755 $(INSTALL_LIBS) $(INSTALL_LIB_DIR)
-	install -m 755 $(INSTALL_OBJS) $(INSTALL_LIB_DIR)
-	install -m 755 $(INSTALL_HDRS) $(INSTALL_INCLUDE_DIR)
+	test -d $(DESTDIR)$(INSTALL_INCLUDE_DIR) || install -m 755 -d $(DESTDIR)$(INSTALL_INCLUDE_DIR)
+	test -d $(DESTDIR)$(INSTALL_LIB_DIR) || install -m 755 -d $(DESTDIR)$(INSTALL_LIB_DIR)
+	test -d $(DESTDIR)$(INSTALL_BIN_DIR) || install -m 755 -d $(DESTDIR)$(INSTALL_BIN_DIR)
+#	install -m 755 libcoprthr_arch_x86_64.so $(DESTDIR)$(INSTALL_LIB_DIR)
+	install -m 755 $(INSTALL_LIBS) $(DESTDIR)$(INSTALL_LIB_DIR)
+	install -m 755 $(INSTALL_OBJS) $(DESTDIR)$(INSTALL_LIB_DIR)
+	install -m 755 $(INSTALL_HDRS) $(DESTDIR)$(INSTALL_INCLUDE_DIR)
 	ln -sf $(INSTALL_LIB_DIR)/$(DEFAULT_E_PLATFORM_LIB) \
-		$(INSTALL_LIB_DIR)/libe_platform.so
+		$(DESTDIR)$(INSTALL_LIB_DIR)/libe_platform.so
 
 uninstall: 
 	rm -f $(INSTALL_LIB_DIR)/libcoprthr_arch_e32.so 

--- a/src/libcoprthr/arch/x86_64/Makefile.in
+++ b/src/libcoprthr/arch/x86_64/Makefile.in
@@ -19,13 +19,12 @@ INSTALL_BIN_DIR=@bindir@
 INSTALL_LIB_DIR=@libdir@
 INSTALL_INCLUDE_DIR=@includedir@
 INSTALL_MAN_DIR=@mandir@
-INSTALL_ICD_DIR=@prefix@/icd/
 
 ### set custom path for ICD files
 #ifneq (@OPENCL_ICD_PATH@,)
 #OPENCL_ICD_PATH=@OPENCL_ICD_PATH@
 #else
-#OPENCL_ICD_PATH=/etc/OpenCL/vendors/
+#OPENCL_ICD_PATH=@sysconfdir@/OpenCL/vendors/
 #endif
 
 ifeq (@ENABLE_SILENT@,1)
@@ -136,18 +135,17 @@ libcoprthr_arch_x86_64.a: $(IMP_OBJS)
 	ar rcv libcoprthr_arch_x86_64.a $(IMP_OBJS)
 
 install: 
-	test -d $(INSTALL_INCLUDE_DIR) || install -m 755 -d $(INSTALL_INCLUDE_DIR)
-	test -d $(INSTALL_LIB_DIR) || install -m 755 -d $(INSTALL_LIB_DIR)
-	test -d $(INSTALL_BIN_DIR) || install -m 755 -d $(INSTALL_BIN_DIR)
-	test -d $(INSTALL_ICD_DIR) || install -m 755 -d $(INSTALL_ICD_DIR)
-#	install -m 755 libcoprthr_arch_x86_64.so $(INSTALL_LIB_DIR)
-	install -m 755 $(INSTALL_LIBS) $(INSTALL_LIB_DIR)
-	install -m 755 $(INSTALL_HDRS) $(INSTALL_INCLUDE_DIR)
+	test -d $(DESTDIR)$(INSTALL_INCLUDE_DIR) || install -m 755 -d $(DESTDIR)$(INSTALL_INCLUDE_DIR)
+	test -d $(DESTDIR)$(INSTALL_LIB_DIR) || install -m 755 -d $(DESTDIR)$(INSTALL_LIB_DIR)
+	test -d $(DESTDIR)$(INSTALL_BIN_DIR) || install -m 755 -d $(DESTDIR)$(INSTALL_BIN_DIR)
+#	install -m 755 libcoprthr_arch_x86_64.so $(DESTDIR)$(INSTALL_LIB_DIR)
+	install -m 755 $(INSTALL_LIBS) $(DESTDIR)$(INSTALL_LIB_DIR)
+	install -m 755 $(INSTALL_HDRS) $(DESTDIR)$(INSTALL_INCLUDE_DIR)
 
 uninstall: 
-#	rm -f $(INSTALL_LIB_DIR)/libcoprthr_arch_x86_64.so 
-	rm -f $(addprefix $(INSTALL_LIB_DIR)/,$(INSTALL_LIBS))
-	rm -f $(addprefix $(INSTALL_INCLUDE_DIR)/,$(INSTALL_HDRS))
+#	rm -f $(DESTDIR)$(INSTALL_LIB_DIR)/libcoprthr_arch_x86_64.so
+	rm -f $(addprefix $(DESTDIR)$(INSTALL_LIB_DIR)/,$(INSTALL_LIBS))
+	rm -f $(addprefix $(DESTDIR)$(INSTALL_INCLUDE_DIR)/,$(INSTALL_HDRS))
 
 clean: 
 	rm -f *.o *.so

--- a/src/libcoprthr_opencl/Makefile.in
+++ b/src/libcoprthr_opencl/Makefile.in
@@ -22,13 +22,12 @@ INSTALL_BIN_DIR=@bindir@
 INSTALL_LIB_DIR=@libdir@
 INSTALL_INCLUDE_DIR=@includedir@
 INSTALL_MAN_DIR=@mandir@
-INSTALL_ICD_DIR=@prefix@/icd/
 
 ### set custom path for ICD files
 ifneq (@OPENCL_ICD_PATH@,)
 OPENCL_ICD_PATH=@OPENCL_ICD_PATH@
 else
-OPENCL_ICD_PATH=/etc/OpenCL/vendors/
+OPENCL_ICD_PATH=@sysconfdir@/OpenCL/vendors/
 endif
 
 ifeq (@ENABLE_SILENT@,1)
@@ -175,32 +174,28 @@ libcoprthr_opencl.a: $(XCL_OBJS)
 
 
 install: 
-	test -d $(INSTALL_INCLUDE_DIR) || install -m 755 -d $(INSTALL_INCLUDE_DIR)
-	test -d $(INSTALL_LIB_DIR) || install -m 755 -d $(INSTALL_LIB_DIR)
-	test -d $(INSTALL_BIN_DIR) || install -m 755 -d $(INSTALL_BIN_DIR)
-	test -d $(INSTALL_ICD_DIR) || install -m 755 -d $(INSTALL_ICD_DIR)
-#	install -m 755 libcoprthr.so $(INSTALL_LIB_DIR)
-#	install -m 755 libcoprthr_opencl.so $(INSTALL_LIB_DIR)
-	install -m 755 $(INSTALL_LIBS) $(INSTALL_LIB_DIR)
-#	install -m 755 sl_engine.h $(INSTALL_INCLUDE_DIR)
-#	install -m 755 ser_engine.h $(INSTALL_INCLUDE_DIR)
-#	install -m 755 workp.h $(INSTALL_INCLUDE_DIR)
-#	install -m 755 opencl_lift.h $(INSTALL_INCLUDE_DIR)/opencl_lift.h
-	test -d $(INSTALL_ICD_DIR) || install -m 755 -d $(INSTALL_ICD_DIR)
-	echo $(INSTALL_LIB_DIR)/libcoprthr_opencl.so > $(INSTALL_ICD_DIR)/coprthr.icd
-	test -d $(OPENCL_ICD_PATH) || install -m 755 -d $(OPENCL_ICD_PATH)
-	install -m 644 $(INSTALL_ICD_DIR)/coprthr.icd $(OPENCL_ICD_PATH)/
+	test -d $(DESTDIR)$(INSTALL_INCLUDE_DIR) || install -m 755 -d $(DESTDIR)$(INSTALL_INCLUDE_DIR)
+	test -d $(DESTDIR)$(INSTALL_LIB_DIR) || install -m 755 -d $(DESTDIR)$(INSTALL_LIB_DIR)
+	test -d $(DESTDIR)$(INSTALL_BIN_DIR) || install -m 755 -d $(DESTDIR)$(INSTALL_BIN_DIR)
+#	install -m 755 libcoprthr.so $(DESTDIR)$(INSTALL_LIB_DIR)
+#	install -m 755 libcoprthr_opencl.so $(DESTDIR)$(INSTALL_LIB_DIR)
+	install -m 755 $(INSTALL_LIBS) $(DESTDIR)$(INSTALL_LIB_DIR)
+#	install -m 755 sl_engine.h $(DESTDIR)$(INSTALL_INCLUDE_DIR)
+#	install -m 755 ser_engine.h $(DESTDIR)$(INSTALL_INCLUDE_DIR)
+#	install -m 755 workp.h $(DESTDIR)$(INSTALL_INCLUDE_DIR)
+#	install -m 755 opencl_lift.h $(DESTDIR)$(INSTALL_INCLUDE_DIR)/opencl_lift.h
+	test -d $(DESTDIR)$(OPENCL_ICD_PATH) || install -m 755 -d $(DESTDIR)$(OPENCL_ICD_PATH)
+	echo $(INSTALL_LIB_DIR)/libcoprthr_opencl.so > $(DESTDIR)$(OPENCL_ICD_PATH)/coprthr.icd
 
 uninstall: 
-#	rm -f $(INSTALL_LIB_DIR)/libcoprthr_opencl.so 
-	rm -f $(addprefix $(INSTALL_LIB_DIR)/,$(INSTALL_LIBS))
-	rm -f $(addprefix $(INSTALL_LIB_DIR)/,$(RT_OBJS))
-	rm -f $(addprefix $(INSTALL_INCLUDE_DIR)/,sl_engine.h)
-	rm -f $(addprefix $(INSTALL_INCLUDE_DIR)/,ser_engine.h)
-	rm -f $(addprefix $(INSTALL_INCLUDE_DIR)/,workp.h)
-	rm -f $(addprefix $(INSTALL_INCLUDE_DIR)/,opencl_lift.h)
-	rm -f $(INSTALL_ICD_DIR)/coprthr.icd
-	rm -f $(OPENCL_ICD_PATH)/coprthr.icd
+#	rm -f $(DESTDIR)$(INSTALL_LIB_DIR)/libcoprthr_opencl.so
+	rm -f $(addprefix $(DESTDIR)$(INSTALL_LIB_DIR)/,$(INSTALL_LIBS))
+	rm -f $(addprefix $(DESTDIR)$(INSTALL_LIB_DIR)/,$(RT_OBJS))
+	rm -f $(addprefix $(DESTDIR)$(INSTALL_INCLUDE_DIR)/,sl_engine.h)
+	rm -f $(addprefix $(DESTDIR)$(INSTALL_INCLUDE_DIR)/,ser_engine.h)
+	rm -f $(addprefix $(DESTDIR)$(INSTALL_INCLUDE_DIR)/,workp.h)
+	rm -f $(addprefix $(DESTDIR)$(INSTALL_INCLUDE_DIR)/,opencl_lift.h)
+	rm -f $(DESTDIR)$(OPENCL_ICD_PATH)/coprthr.icd
 
 clean:
 	rm -f *.o *.so

--- a/src/libcoprthrcc/Makefile.in
+++ b/src/libcoprthrcc/Makefile.in
@@ -22,13 +22,12 @@ INSTALL_BIN_DIR=@bindir@
 INSTALL_LIB_DIR=@libdir@
 INSTALL_INCLUDE_DIR=@includedir@
 INSTALL_MAN_DIR=@mandir@
-INSTALL_ICD_DIR=@prefix@/icd/
 
 ### set custom path for ICD files
 #ifneq (@OPENCL_ICD_PATH@,)
 #OPENCL_ICD_PATH=@OPENCL_ICD_PATH@
 #else
-#OPENCL_ICD_PATH=/etc/OpenCL/vendors/
+#OPENCL_ICD_PATH=@sysconfdir@/OpenCL/vendors/
 #endif
 
 ifeq (@ENABLE_SILENT@,1)
@@ -234,27 +233,24 @@ compiler_android_arm32.o: compiler_cross.c
 
 
 install: 
-	test -d $(INSTALL_INCLUDE_DIR) || install -m 755 -d $(INSTALL_INCLUDE_DIR)
-	test -d $(INSTALL_INCLUDE_DIR)/coprthr \
-		 || install -m 755 -d $(INSTALL_INCLUDE_DIR)/coprthr
-	test -d $(INSTALL_LIB_DIR) || install -m 755 -d $(INSTALL_LIB_DIR)
-	test -d $(INSTALL_BIN_DIR) || install -m 755 -d $(INSTALL_BIN_DIR)
-	test -d $(INSTALL_ICD_DIR) || install -m 755 -d $(INSTALL_ICD_DIR)
-	install -m 755 $(INSTALL_HDRS) $(INSTALL_INCLUDE_DIR)
-	install -m 755 $(INSTALL_COPRTHR_HDRS) $(INSTALL_INCLUDE_DIR)/coprthr
-	install -m 755 $(INSTALL_LIBS) $(INSTALL_LIB_DIR)
-	install -m 755 opencl_lift.h $(INSTALL_INCLUDE_DIR)/opencl_lift.h
+	test -d $(DESTDIR)$(INSTALL_INCLUDE_DIR) || install -m 755 -d $(DESTDIR)$(INSTALL_INCLUDE_DIR)
+	test -d $(DESTDIR)$(INSTALL_INCLUDE_DIR)/coprthr \
+		 || install -m 755 -d $(DESTDIR)$(INSTALL_INCLUDE_DIR)/coprthr
+	test -d $(DESTDIR)$(INSTALL_LIB_DIR) || install -m 755 -d $(DESTDIR)$(INSTALL_LIB_DIR)
+	test -d $(DESTDIR)$(INSTALL_BIN_DIR) || install -m 755 -d $(DESTDIR)$(INSTALL_BIN_DIR)
+	install -m 755 $(INSTALL_HDRS) $(DESTDIR)$(INSTALL_INCLUDE_DIR)
+	install -m 755 $(INSTALL_COPRTHR_HDRS) $(DESTDIR)$(INSTALL_INCLUDE_DIR)/coprthr
+	install -m 755 $(INSTALL_LIBS) $(DESTDIR)$(INSTALL_LIB_DIR)
+	install -m 755 opencl_lift.h $(DESTDIR)$(INSTALL_INCLUDE_DIR)/opencl_lift.h
 
 uninstall: 
-#	rm -f $(INSTALL_LIB_DIR)/libcoprthr.so 
-#	rm -f $(INSTALL_LIB_DIR)/libcoprthrcc.so 
-	rm -f $(addprefix $(INSTALL_LIB_DIR)/,$(INSTALL_LIBS))
-#	rm -f $(addprefix $(INSTALL_INCLUDE_DIR)/,sl_engine.h)
-#	rm -f $(addprefix $(INSTALL_INCLUDE_DIR)/,ser_engine.h)
-#	rm -f $(addprefix $(INSTALL_INCLUDE_DIR)/,workp.h)
-#	rm -f $(addprefix $(INSTALL_INCLUDE_DIR)/,opencl_lift.h)
-#	rm -f $(INSTALL_ICD_DIR)/coprthr.icd
-#	rm -f $(OPENCL_ICD_PATH)/coprthr.icd
+#	rm -f $(DESTDIR)$(INSTALL_LIB_DIR)/libcoprthr.so
+#	rm -f $(DESTDIR)$(INSTALL_LIB_DIR)/libcoprthrcc.so
+	rm -f $(addprefix $(DESTDIR)$(INSTALL_LIB_DIR)/,$(INSTALL_LIBS))
+#	rm -f $(addprefix $(DESTDIR)$(INSTALL_INCLUDE_DIR)/,sl_engine.h)
+#	rm -f $(addprefix $(DESTDIR)$(INSTALL_INCLUDE_DIR)/,ser_engine.h)
+#	rm -f $(addprefix $(DESTDIR)$(INSTALL_INCLUDE_DIR)/,workp.h)
+#	rm -f $(addprefix $(DESTDIR)$(INSTALL_INCLUDE_DIR)/,opencl_lift.h)
 
 clean:
 	rm -f *.o *.so

--- a/src/libocl/Makefile.in
+++ b/src/libocl/Makefile.in
@@ -19,6 +19,13 @@ LIBELF_LIB=@LIBELF_LIB@
 
 LIBEVENT_INC=@LIBEVENT_INC@
 
+### set custom path for ICD files
+ifneq (@OPENCL_ICD_PATH@,)
+OPENCL_ICD_PATH=@OPENCL_ICD_PATH@
+else
+OPENCL_ICD_PATH=@sysconfdir@/OpenCL/vendors/
+endif
+
 #DEFS += -DOCL_DEBUG 
 #DEFS += -DOCL_WARN
 
@@ -40,9 +47,7 @@ OBJS = libocl.o oclcall.o
 
 DEFS += -DINSTALL_LIB_DIR=\"$(INSTALL_LIB_DIR)\" 
 
-ifneq (@OPENCL_ICD_PATH@,)
-DEFS += -DOPENCL_ICD_PATH=\"@OPENCL_ICD_PATH@\"
-endif
+DEFS += -DOPENCL_ICD_PATH=\"$(OPENCL_ICD_PATH)\"
 
 #ifeq (@ENABLE_DEBUG_LIBS@,1)
 #DEFS += -DOCL_DEBUG 
@@ -63,11 +68,7 @@ DEFS += -DENABLE_LIBOCL_HOOK
 OBJS += oclcall_hook.o
 endif
 
-ifeq (@ENABLE_USER_INSTALL@,1)
-VAR_CLPROC_PATH=$(prefix)/var/clproc
-else
-VAR_CLPROC_PATH=/var/clproc
-endif
+VAR_CLPROC_PATH=@localstatedir@/clproc
 
 ######################################################################
 
@@ -163,26 +164,26 @@ debug:
 
 
 install: 
-	test -d $(INSTALL_INCLUDE_DIR) || install -m 755 -d $(INSTALL_INCLUDE_DIR)
-	test -d $(INSTALL_LIB_DIR) || install -m 755 -d $(INSTALL_LIB_DIR)
-	test -d $(INSTALL_BIN_DIR) || install -m 755 -d $(INSTALL_BIN_DIR)
-	install -m 755 libocl.so $(INSTALL_LIB_DIR)
-	install -m 755 $(INSTALL_LIBS) $(INSTALL_LIB_DIR)
-#	install -m 755 libocl_d.so $(INSTALL_LIB_DIR)
-#	ln -sf $(INSTALL_LIB_DIR)/libocl.so $(INSTALL_LIB_DIR)/libOpenCL.so
+	test -d $(DESTDIR)$(INSTALL_INCLUDE_DIR) || install -m 755 -d $(DESTDIR)$(INSTALL_INCLUDE_DIR)
+	test -d $(DESTDIR)$(INSTALL_LIB_DIR) || install -m 755 -d $(DESTDIR)$(INSTALL_LIB_DIR)
+	test -d $(DESTDIR)$(INSTALL_BIN_DIR) || install -m 755 -d $(DESTDIR)$(INSTALL_BIN_DIR)
+	install -m 755 libocl.so $(DESTDIR)$(INSTALL_LIB_DIR)
+	install -m 755 $(INSTALL_LIBS) $(DESTDIR)$(INSTALL_LIB_DIR)
+#	install -m 755 libocl_d.so $(DESTDIR)$(INSTALL_LIB_DIR)
+#	ln -sf $(INSTALL_LIB_DIR)/libocl.so $(DESTDIR)$(INSTALL_LIB_DIR)/libOpenCL.so
 #ifeq ($(ENABLE_DEBUG_LIBCOPRTHR),1)
-#	ln -sf $(INSTALL_LIB_DIR)/libocl_d.so $(INSTALL_LIB_DIR)/libOpenCL_d.so
+#	ln -sf $(INSTALL_LIB_DIR)/libocl_d.so $(DESTDIR)$(INSTALL_LIB_DIR)/libOpenCL_d.so
 #endif
 ifneq (@ENABLE_ANDROID_CROSS_COMPILE@,1)
-	test -d $(VAR_CLPROC_PATH) || install -m 777 -d $(VAR_CLPROC_PATH)
+	test -d $(DESTDIR)$(VAR_CLPROC_PATH) || install -m 777 -d $(DESTDIR)$(VAR_CLPROC_PATH)
 endif
 
 uninstall: 
-#	rm -f $(INSTALL_LIB_DIR)/libocl.so $(INSTALL_LIB_DIR)/libocl_d.so
-#	rm -f $(INSTALL_LIB_DIR)/libOpenCL.so $(INSTALL_LIB_DIR)/libOpenCL_d.so
-#	rm -f $(INSTALL_LIB_DIR)/libocl.so 
-	rm -f $(addprefix $(INSTALL_LIB_DIR)/,$(INSTALL_LIBS))
-#	rm -f $(INSTALL_LIB_DIR)/libOpenCL.so 
+#	rm -f $(DESTDIR)$(INSTALL_LIB_DIR)/libocl.so $(DESTDIR)$(INSTALL_LIB_DIR)/libocl_d.so
+#	rm -f $(DESTDIR)$(INSTALL_LIB_DIR)/libOpenCL.so $(DESTDIR)$(INSTALL_LIB_DIR)/libOpenCL_d.so
+#	rm -f $(DESTDIR)$(INSTALL_LIB_DIR)/libocl.so
+	rm -f $(addprefix $(DESTDIR)$(INSTALL_LIB_DIR)/,$(INSTALL_LIBS))
+#	rm -f $(DESTDIR)$(INSTALL_LIB_DIR)/libOpenCL.so
 
 clean:
 	rm -f *.o *.so *.a

--- a/src/libocl/cltop.c
+++ b/src/libocl/cltop.c
@@ -11,6 +11,10 @@
 
 #include "clproc.h"
 
+#ifndef VAR_CLPROC_PATH
+#warning VAR_CLPROC_PATH not defined
+#endif
+
 /*** brief
   PID|USERNAME|STATE| GMEM| NDEV|CMDS/Q  |KRNS/Q  |ERRS|ERR|TWAIT|COMMAND      |
     5        8     5     5     5    4/3      4/3      4/3       5 13
@@ -64,7 +68,7 @@ int main()
 
 		fprintf( stdout, TABLE_HEADER_BRIEF "\n" );
 	
-		DIR* dirp = opendir( "/var/clproc/" );
+		DIR* dirp = opendir( VAR_CLPROC_PATH );
 
 		struct dirent* dp;
 
@@ -74,7 +78,7 @@ int main()
 
 			if (!pid) continue;
 
-			snprintf(filename,64,"/var/clproc/%d/state",(int)pid);
+			snprintf(filename,64,VAR_CLPROC_PATH "/%d/state",(int)pid);
 
 			struct stat fs;
 			struct passwd* pwd = (struct passwd*)malloc(sizeof(struct passwd));

--- a/src/libocl/libocl.c
+++ b/src/libocl/libocl.c
@@ -54,13 +54,8 @@
 
 #include <errno.h>
 
-#ifndef DEFAULT_OPENCL_ICD_PATH
-#define DEFAULT_OPENCL_ICD_PATH "/etc/OpenCL/vendors"
-#endif
-
 #ifndef VAR_CLPROC_PATH
 #warning VAR_CLPROC_PATH not defined
-#define VAR_CLPROC_PATH "/var/clproc"
 #endif
 
 #define min(a,b) ((a<b)?a:b)

--- a/src/libstdcl/Makefile.in
+++ b/src/libstdcl/Makefile.in
@@ -181,24 +181,24 @@ check_root:
 
 
 install: check_root $(INSTALL_INCS) $(INSTALL_LIBS) $(addsuffix .gz,$(MAN3))
-	test -d $(INSTALL_INCLUDE_DIR) || install -m 755 -d $(INSTALL_INCLUDE_DIR)
-	test -d $(INSTALL_LIB_DIR) || install -m 755 -d $(INSTALL_LIB_DIR)
-	test -d $(INSTALL_MAN_DIR)/man3 || install -m 755 -d $(INSTALL_MAN_DIR)/man3
-	install -m 644 $(INSTALL_INCS) $(INSTALL_INCLUDE_DIR)
+	test -d $(DESTDIR)$(INSTALL_INCLUDE_DIR) || install -m 755 -d $(DESTDIR)$(INSTALL_INCLUDE_DIR)
+	test -d $(DESTDIR)$(INSTALL_LIB_DIR) || install -m 755 -d $(DESTDIR)$(INSTALL_LIB_DIR)
+	test -d $(DESTDIR)$(INSTALL_MAN_DIR)/man3 || install -m 755 -d $(DESTDIR)$(INSTALL_MAN_DIR)/man3
+	install -m 644 $(INSTALL_INCS) $(DESTDIR)$(INSTALL_INCLUDE_DIR)
 ifneq ($(F90),)
-	install -m 644 $(MODS) $(INSTALL_INCLUDE_DIR)
+	install -m 644 $(MODS) $(DESTDIR)$(INSTALL_INCLUDE_DIR)
 endif
-	install -m 644 $(INSTALL_LIBS) $(INSTALL_LIB_DIR)
-	install -m 644 $(addsuffix .gz,$(MAN3)) $(INSTALL_MAN_DIR)/man3
+	install -m 644 $(INSTALL_LIBS) $(DESTDIR)$(INSTALL_LIB_DIR)
+	install -m 644 $(addsuffix .gz,$(MAN3)) $(DESTDIR)$(INSTALL_MAN_DIR)/man3
 
 uninstall: check_root
-	rm -f $(addprefix $(INSTALL_INC_DIR)/,$(INSTALL_INCS)) 
+	rm -f $(addprefix $(DESTDIR)$(INSTALL_INC_DIR)/,$(INSTALL_INCS))
 ifneq ($(F90),)
-	rm -f $(addprefix $(INSTALL_INC_DIR)/,$(MODS)) 
+	rm -f $(addprefix $(DESTDIR)$(INSTALL_INC_DIR)/,$(MODS))
 endif
-	rm -f $(addprefix $(INSTALL_LIB_DIR)/,$(INSTALL_LIBS)) 
-	rm -f $(addprefix $(INSTALL_BIN_DIR)/,$(INSTALL_BINS)) 
-	rm -f $(addprefix $(INSTALL_MAN_DIR)/man3/,$(addsuffix .gz,$(MAN3)))
+	rm -f $(addprefix $(DESTDIR)$(INSTALL_LIB_DIR)/,$(INSTALL_LIBS))
+	rm -f $(addprefix $(DESTDIR)$(INSTALL_BIN_DIR)/,$(INSTALL_BINS))
+	rm -f $(addprefix $(DESTDIR)$(INSTALL_MAN_DIR)/man3/,$(addsuffix .gz,$(MAN3)))
 
 
 clean:

--- a/test/test_libcoprthr_opencl/Makefile.in
+++ b/test/test_libcoprthr_opencl/Makefile.in
@@ -5,8 +5,8 @@ exec_prefix=@exec_prefix@
 #OPENCL_INC_DIR = @OPENCL_INCLUDE@
 #OPENCL_LIB_DIR = @OPENCL_LIB@
 #OPENCL_LIBNAME = @OPENCL_LIBNAME@
-OPENCL_INC_DIR = $(prefix)/include
-OPENCL_LIB_DIR = $(prefix)/lib
+OPENCL_INC_DIR = @includedir@
+OPENCL_LIB_DIR = @libdir@
 OPENCL_LIBNAME = coprthr_opencl
 
 USE_OPENCL_INCS=-I$(OPENCL_INC_DIR)

--- a/tools/clcc/Makefile.in
+++ b/tools/clcc/Makefile.in
@@ -72,14 +72,14 @@ $(BIN_NAME): $(OBJS)
 	-gzip -f -c $*.1 > $*.1.gz
 
 install:
-	test -d $(INSTALL_BIN_DIR) || install -m 755 -d $(INSTALL_BIN_DIR)
-	test -d $(INSTALL_MAN_DIR)/man1 || install -m 755 -d $(INSTALL_MAN_DIR)/man1
-	install -m 755 $(BIN_NAME) $(INSTALL_BIN_DIR)
-#	install -m 644 $(addsuffix .gz,$(MAN1)) $(INSTALL_MAN_DIR)/man1
+	test -d $(DESTDIR)$(INSTALL_BIN_DIR) || install -m 755 -d $(DESTDIR)$(INSTALL_BIN_DIR)
+	test -d $(DESTDIR)$(INSTALL_MAN_DIR)/man1 || install -m 755 -d $(DESTDIR)$(INSTALL_MAN_DIR)/man1
+	install -m 755 $(BIN_NAME) $(DESTDIR)$(INSTALL_BIN_DIR)
+#	install -m 644 $(addsuffix .gz,$(MAN1)) $(DESTDIR)$(INSTALL_MAN_DIR)/man1
 
 uninstall:
-	rm -f $(INSTALL_BIN_DIR)/$(BIN_NAME)
-#	rm -f $(addsuffix .gz,$(addprefix $(INSTALL_MAN_DIR)/man1/,$(MAN1)))
+	rm -f $(DESTDIR)$(INSTALL_BIN_DIR)/$(BIN_NAME)
+#	rm -f $(addsuffix .gz,$(addprefix $(DESTDIR)$(INSTALL_MAN_DIR)/man1/,$(MAN1)))
 
 clean:
 	rm -f *.o 

--- a/tools/clcc/Makefile.in
+++ b/tools/clcc/Makefile.in
@@ -40,6 +40,7 @@ LIBELF_LIB = @LIBELF_LIB@
 LIB_MIC_LIBS = -L@LIB_MIC_PATH@ -limf -lsvml -lirng -lintlc
 
 INCS = -I$(OPENCL_INC_DIR)
+INCS += $(LIBELF_INC)
 
 LIBS = $(LIBELF_LIB) 
 LIBS += -L../../src/libclelf -lclelf

--- a/tools/clcc1/Makefile.in
+++ b/tools/clcc1/Makefile.in
@@ -76,14 +76,14 @@ $(BIN_NAME): $(OBJS)
 	-gzip -f -c $*.1 > $*.1.gz
 
 install:
-	test -d $(INSTALL_BIN_DIR) || install -m 755 -d $(INSTALL_BIN_DIR)
-	test -d $(INSTALL_MAN_DIR)/man1 || install -m 755 -d $(INSTALL_MAN_DIR)/man1
-	install -m 755 $(BIN_NAME) $(INSTALL_BIN_DIR)
-#	install -m 644 $(addsuffix .gz,$(MAN1)) $(INSTALL_MAN_DIR)/man1
+	test -d $(DESTDIR)$(INSTALL_BIN_DIR) || install -m 755 -d $(DESTDIR)$(INSTALL_BIN_DIR)
+	test -d $(DESTDIR)$(INSTALL_MAN_DIR)/man1 || install -m 755 -d $(DESTDIR)$(INSTALL_MAN_DIR)/man1
+	install -m 755 $(BIN_NAME) $(DESTDIR)$(INSTALL_BIN_DIR)
+#	install -m 644 $(addsuffix .gz,$(MAN1)) $(DESTDIR)$(INSTALL_MAN_DIR)/man1
 
 uninstall:
-	rm -f $(INSTALL_BIN_DIR)/$(BIN_NAME)
-#	rm -f $(addsuffix .gz,$(addprefix $(INSTALL_MAN_DIR)/man1/,$(MAN1)))
+	rm -f $(DESTDIR)$(INSTALL_BIN_DIR)/$(BIN_NAME)
+#	rm -f $(addsuffix .gz,$(addprefix $(DESTDIR)$(INSTALL_MAN_DIR)/man1/,$(MAN1)))
 
 clean:
 	rm -f *.o 

--- a/tools/clld/Makefile.in
+++ b/tools/clld/Makefile.in
@@ -76,14 +76,14 @@ $(BIN_NAME): $(OBJS)
 	-gzip -f -c $*.1 > $*.1.gz
 
 install: 
-	test -d $(INSTALL_BIN_DIR) || install -m 755 -d $(INSTALL_BIN_DIR)
-	test -d $(INSTALL_MAN_DIR)/man1 || install -m 755 -d $(INSTALL_MAN_DIR)/man1
-	install -m 755 $(BIN_NAME) $(INSTALL_BIN_DIR)
-#	install -m 644 $(addsuffix .gz,$(MAN1)) $(INSTALL_MAN_DIR)/man1
+	test -d $(DESTDIR)$(INSTALL_BIN_DIR) || install -m 755 -d $(DESTDIR)$(INSTALL_BIN_DIR)
+	test -d $(DESTDIR)$(INSTALL_MAN_DIR)/man1 || install -m 755 -d $(DESTDIR)$(INSTALL_MAN_DIR)/man1
+	install -m 755 $(BIN_NAME) $(DESTDIR)$(INSTALL_BIN_DIR)
+#	install -m 644 $(addsuffix .gz,$(MAN1)) $(DESTDIR)$(INSTALL_MAN_DIR)/man1
 
 uninstall:
-	rm -f $(INSTALL_BIN_DIR)/$(BIN_NAME)
-#	rm -f $(addsuffix .gz,$(addprefix $(INSTALL_MAN_DIR)/man1/,$(MAN1)))
+	rm -f $(DESTDIR)$(INSTALL_BIN_DIR)/$(BIN_NAME)
+#	rm -f $(addsuffix .gz,$(addprefix $(DESTDIR)$(INSTALL_MAN_DIR)/man1/,$(MAN1)))
 
 clean:
 	rm -f *.o 

--- a/tools/clnm/Makefile.in
+++ b/tools/clnm/Makefile.in
@@ -62,14 +62,14 @@ $(BIN_NAME): $(OBJS)
 	-gzip -f -c $*.1 > $*.1.gz
 
 install: 
-	test -d $(INSTALL_BIN_DIR) || install -m 755 -d $(INSTALL_BIN_DIR)
-	test -d $(INSTALL_MAN_DIR)/man1 || install -m 755 -d $(INSTALL_MAN_DIR)/man1
-	install -m 755 $(BIN_NAME) $(INSTALL_BIN_DIR)
-#	install -m 644 $(addsuffix .gz,$(MAN1)) $(INSTALL_MAN_DIR)/man1
+	test -d $(DESTDIR)$(INSTALL_BIN_DIR) || install -m 755 -d $(DESTDIR)$(INSTALL_BIN_DIR)
+	test -d $(DESTDIR)$(INSTALL_MAN_DIR)/man1 || install -m 755 -d $(DESTDIR)$(INSTALL_MAN_DIR)/man1
+	install -m 755 $(BIN_NAME) $(DESTDIR)$(INSTALL_BIN_DIR)
+#	install -m 644 $(addsuffix .gz,$(MAN1)) $(DESTDIR)$(INSTALL_MAN_DIR)/man1
 
 uninstall: 
-	rm -f $(INSTALL_BIN_DIR)/$(BIN_NAME)
-#	rm -f $(addsuffix .gz,$(addprefix $(INSTALL_MAN_DIR)/man1/,$(MAN1)))
+	rm -f $(DESTDIR)$(INSTALL_BIN_DIR)/$(BIN_NAME)
+#	rm -f $(addsuffix .gz,$(addprefix $(DESTDIR)$(INSTALL_MAN_DIR)/man1/,$(MAN1)))
 
 clean:
 	rm -f *.o 

--- a/tools/cltop/Makefile.in
+++ b/tools/cltop/Makefile.in
@@ -20,11 +20,7 @@ ifneq (@DEFAULT_CLMESG_LEVEL@,)
 DEFS += -DDEFAULT_CLMESG_LEVEL=@DEFAULT_CLMESG_LEVEL@
 endif
 
-ifeq (@ENABLE_USER_INSTALL@,1)
-VAR_CLPROC_PATH=$(prefix)/var/clproc
-else
-VAR_CLPROC_PATH=/var/clproc
-endif
+VAR_CLPROC_PATH=@localstatedir@/clproc
 
 ######################################################################
 
@@ -63,11 +59,11 @@ $(BIN_NAME): $(OBJS)
 #	-gzip -f -c $*.1 > $*.1.gz
 
 install:
-	test -d $(INSTALL_BIN_DIR) || install -m 755 -d $(INSTALL_BIN_DIR)
-	install -m 755 $(BIN_NAME) $(INSTALL_BIN_DIR)
+	test -d $(DESTDIR)$(INSTALL_BIN_DIR) || install -m 755 -d $(DESTDIR)$(INSTALL_BIN_DIR)
+	install -m 755 $(BIN_NAME) $(DESTDIR)$(INSTALL_BIN_DIR)
 
 uninstall:
-	rm -f $(INSTALL_BIN_DIR)/$(BIN_NAME)
+	rm -f $(DESTDIR)$(INSTALL_BIN_DIR)/$(BIN_NAME)
 
 clean:
 	rm -f *.o 

--- a/tools/cltop/cltop.c
+++ b/tools/cltop/cltop.c
@@ -12,7 +12,7 @@
 #include "clproc.h"
 
 #ifndef VAR_CLPROC_PATH
-#define VAR_CLPROC_PATH "/var/clproc"
+#warning VAR_CLPROC_PATH not defined
 #endif
 
 /*** brief
@@ -68,7 +68,6 @@ int main()
 
 		fprintf( stdout, TABLE_HEADER_BRIEF "\n" );
 	
-//		DIR* dirp = opendir( "/var/clproc/" );
 		DIR* dirp = opendir( VAR_CLPROC_PATH );
 
 		struct dirent* dp;
@@ -79,7 +78,6 @@ int main()
 
 			if (!pid) continue;
 
-//			snprintf(filename,64,"/var/clproc/%d/state",(int)pid);
 			snprintf(filename,64,VAR_CLPROC_PATH"/%d/state",(int)pid);
 
 			struct stat fs;
@@ -116,7 +114,6 @@ int main()
 
 			char* str_cmdline = (char*)malloc(16);
 			//snprintf(filename,64,"/proc/%d/cmdline",(int)pid);
-//			snprintf(filename,64,"/var/clproc/%d/cmdline",(int)pid);
 			snprintf(filename,64,VAR_CLPROC_PATH"/%d/cmdline",(int)pid);
 			fd = open(filename,O_RDONLY);
 			if ( !fstat(fd,&fs) )

--- a/tools/cltrace/Makefile.in
+++ b/tools/cltrace/Makefile.in
@@ -79,16 +79,16 @@ libcltrace1.so: _interceptor.h libcltrace1.o
 	-gzip -f -c $*.1 > $*.1.gz
 
 install:
-	test -d $(INSTALL_BIN_DIR) || install -m 755 -d $(INSTALL_BIN_DIR)
-	test -d $(INSTALL_LIB_DIR) || install -m 755 -d $(INSTALL_LIB_DIR)
-	install -m 755 $(BIN_NAME) $(INSTALL_BIN_DIR)
-	install -m 644 $(INSTALL_LIBS) $(INSTALL_LIB_DIR)
-	install -m 644 $(addsuffix .gz,$(MAN1)) $(INSTALL_MAN_DIR)/man1
+	test -d $(DESTDIR)$(INSTALL_BIN_DIR) || install -m 755 -d $(DESTDIR)$(INSTALL_BIN_DIR)
+	test -d $(DESTDIR)$(INSTALL_LIB_DIR) || install -m 755 -d $(DESTDIR)$(INSTALL_LIB_DIR)
+	install -m 755 $(BIN_NAME) $(DESTDIR)$(INSTALL_BIN_DIR)
+	install -m 644 $(INSTALL_LIBS) $(DESTDIR)$(INSTALL_LIB_DIR)
+	install -m 644 $(addsuffix .gz,$(MAN1)) $(DESTDIR)$(INSTALL_MAN_DIR)/man1
 
 uninstall:
-	rm -f $(INSTALL_BIN_DIR)/$(BIN_NAME)
-	rm -f $(addprefix $(INSTALL_LIB_DIR)/,$(INSTALL_LIBS))
-	rm -f $(addsuffix .gz,$(addprefix $(INSTALL_MAN)/man1/,$(MAN1)))
+	rm -f $(DESTDIR)$(INSTALL_BIN_DIR)/$(BIN_NAME)
+	rm -f $(addprefix $(DESTDIR)$(INSTALL_LIB_DIR)/,$(INSTALL_LIBS))
+	rm -f $(addsuffix .gz,$(addprefix $(DESTDIR)$(INSTALL_MAN)/man1/,$(MAN1)))
 
 clean:
 	rm -f *.o *.so

--- a/tools/scripts/Makefile.in
+++ b/tools/scripts/Makefile.in
@@ -45,11 +45,11 @@ all: $(BIN_NAME)
 #	-gzip -f -c $*.1 > $*.1.gz
 
 install:
-	test -d $(INSTALL_BIN_DIR) || install -m 755 -d $(INSTALL_BIN_DIR)
-	install -m 755 $(BIN_NAME) $(INSTALL_BIN_DIR)
+	test -d $(DESTDIR)$(INSTALL_BIN_DIR) || install -m 755 -d $(DESTDIR)$(INSTALL_BIN_DIR)
+	install -m 755 $(BIN_NAME) $(DESTDIR)$(INSTALL_BIN_DIR)
 
 uninstall:
-	rm -f $(addprefix $(INSTALL_BIN_DIR)/,$(BIN_NAME))
+	rm -f $(addprefix $(DESTDIR)$(INSTALL_BIN_DIR)/,$(BIN_NAME))
 
 clean:
 	rm -f *.o 

--- a/tools/scripts/clprocd.in
+++ b/tools/scripts/clprocd.in
@@ -5,7 +5,7 @@ args=`getopt m:d: $*`
 set -- $args
 
 cmin=5
-dir=/var/clproc
+dir=@localstatedir@/clproc
 
 for i
 do
@@ -23,7 +23,7 @@ done
 while :
 do
 
-#pids=`ls /var/clproc`
+#pids=`ls @localstatedir@/clproc`
 pids=`ls $dir`
 
 #echo $pids

--- a/tools/xclnm/Makefile.in
+++ b/tools/xclnm/Makefile.in
@@ -74,10 +74,10 @@ xclnm_scan.c: xclnm_scan.l xclnm_gram.c xclnm_gram.h
 	$(CC) $(CFLAGS) $(DEFS) $(INCS) -c $<
 
 install:
-	install -m 755 $(BIN_NAME) $(INSTALL_BIN_DIR)
+	install -m 755 $(BIN_NAME) $(DESTDIR)$(INSTALL_BIN_DIR)
 
 uninstall:
-	rm -f $(INSTALL_BIN_DIR)/$(BIN_NAME)
+	rm -f $(DESTDIR)$(INSTALL_BIN_DIR)/$(BIN_NAME)
 
 clean:
 	rm -f *.o 


### PR DESCRIPTION
Various changes to make coprthr easier to package and distribute, mostly related to implementing the DESTDIR variable. See www.gnu.org/prep/standards/html_node/DESTDIR.html for information about DESTDIR (Arch Linux frequently uses it when building packages).

The use of sysconfdir and localstatedir as opposed to "enable-user-install" should also make it easier to prepare a FreeBSD port--from what I recall of the ports tree.
