### PR TITLE
libcoprthr_opencl: clGetDeviceInfo for CL_DEVICE_EXTENSIONS causes segfault

### DIFF
--- a/src/libcoprthr/arch/e32/device_e32.c
+++ b/src/libcoprthr/arch/e32/device_e32.c
@@ -206,6 +206,7 @@ static int init_device_e32(void)
 	codev->devinfo->drv_version = 0;
 	codev->devinfo->profile = 0;
 	codev->devinfo->version = 0;
+	codev->devinfo->extensions = 0;
 
 	
 	codev->devinfo->max_compute_units 
@@ -227,6 +228,7 @@ static int init_device_e32(void)
 	__terminate(codev->devinfo->drv_version);
 	__terminate(codev->devinfo->profile);
 	__terminate(codev->devinfo->version);
+	__terminate(codev->devinfo->extensions);
 
 
 

--- a/src/libcoprthr/arch/e32_legacy/device_e32.c
+++ b/src/libcoprthr/arch/e32_legacy/device_e32.c
@@ -273,6 +273,7 @@ printcl(CL_DEBUG "back from old_e_get_platform_info");
 	codev->devinfo->drv_version = 0;
 	codev->devinfo->profile = 0;
 	codev->devinfo->version = 0;
+	codev->devinfo->extensions = 0;
 
 	
 /*
@@ -454,6 +455,7 @@ printcl(CL_DEBUG "back from old_e_get_platform_info");
 	__terminate(codev->devinfo->drv_version);
 	__terminate(codev->devinfo->profile);
 	__terminate(codev->devinfo->version);
+	__terminate(codev->devinfo->extensions);
 
 
 

--- a/src/libcoprthr/arch/x86_64/device_x86_64.c
+++ b/src/libcoprthr/arch/x86_64/device_x86_64.c
@@ -121,6 +121,7 @@ static int init_device_x86_64(void)
 	codev->devinfo->drv_version = 0;
 	codev->devinfo->profile = 0;
 	codev->devinfo->version = 0;
+	codev->devinfo->extensions = 0;
 
 	FILE* fp;
 	struct stat fs;
@@ -308,6 +309,7 @@ codev->devinfo->vendor = strdup("Xilinx");
 	__terminate(codev->devinfo->drv_version);
 	__terminate(codev->devinfo->profile);
 	__terminate(codev->devinfo->version);
+	__terminate(codev->devinfo->extensions);
 
 
 


### PR DESCRIPTION
When using libcopthr_opencl (through libocl), probing for device extensions with clGetDeviceInfo causes a segfault. Backtracing fingers the call to "strnlen" as the culprit, due to the "extensions" field of devinfo not being initialized.

Originally discovered trying to use the OpenCL backend for Octopus, but can be reproduced by extending clinfo.x in the test suite to probe device extensions as well.
